### PR TITLE
ionic.keyboard version 1.0.3 -> 1.0.4

### DIFF
--- a/.meteor/cordova-plugins
+++ b/.meteor/cordova-plugins
@@ -1,1 +1,1 @@
-com.ionic.keyboard@1.0.3
+com.ionic.keyboard@1.0.4


### PR DESCRIPTION
ionic-keyboard-plugin probably never had a version 1.0.3 or was pulled from github releases.
https://github.com/driftyco/ionic-plugin-keyboard/releases
